### PR TITLE
Fix broken volume-driver and plugin-install

### DIFF
--- a/docker-plugin/docker-tests/secondnode.bats
+++ b/docker-plugin/docker-tests/secondnode.bats
@@ -4,11 +4,13 @@ load "../../test_helper"
 
 @test "Test: Install plugin for driver ($driver) on node 2" {
   #skip "This test works, faster for rev without it"
-  run $prefix -t "docker plugin ls | grep $driver"
+  run $prefix2 -t "docker plugin ls | grep $driver"
   if [[ $status -eq 0 ]]; then
     skip
   fi
 
+  run $prefix2 docker plugin disable storageos -f
+  run $prefix2 docker plugin rm storageos
   run $prefix2 docker plugin install --grant-all-permissions $driver $pluginopts
   sleep 60
   assert_success

--- a/docker-plugin/docker-tests/singlenode.bats
+++ b/docker-plugin/docker-tests/singlenode.bats
@@ -9,9 +9,11 @@ load "../../test_helper"
     skip
   fi
 
+  run $prefix docker plugin disable storageos -f
+  run $prefix docker plugin rm storageos
   run $prefix docker plugin install --grant-all-permissions $driver $pluginopts
-  sleep 60
   assert_success
+  sleep 60
 }
 
 @test "Test: Create volume using driver ($driver)" {

--- a/docker-plugin/install/install_plugin.bats
+++ b/docker-plugin/install/install_plugin.bats
@@ -20,9 +20,9 @@ CID_FILE=$BATS_TEST_DIRNAME/CID
   fi
 
 
- set -x
-  run $prefix docker plugin install --grant-all-permissions $driver CLUSTER_ID=$(cat $CID_FILE)
-  set +x
+ #set -x
+  run $prefix docker plugin install --alias storageos --grant-all-permissions $driver CLUSTER_ID=$(cat $CID_FILE)
+  #set +x
   assert_success
 }
 
@@ -33,7 +33,7 @@ CID_FILE=$BATS_TEST_DIRNAME/CID
     skip
   fi
 
-  run $prefix2 docker plugin install --grant-all-permissions $driver CLUSTER_ID=$(cat $CID_FILE)
+  run $prefix2 docker plugin install --alias storageos --grant-all-permissions $driver CLUSTER_ID=$(cat $CID_FILE)
   assert_success
 }
 
@@ -44,6 +44,6 @@ CID_FILE=$BATS_TEST_DIRNAME/CID
     skip
   fi
 
-  run $prefix3 docker plugin install --grant-all-permissions $driver "CLUSTER_ID=$(cat $CID_FILE)"
+  run $prefix3 docker plugin install --alias storageos --grant-all-permissions $driver "CLUSTER_ID=$(cat $CID_FILE)"
   assert_success
 }


### PR DESCRIPTION
Some tests use the storageos volume-driver, however soegarots is used in
testing. This has been fixed by using an alias.

Using the alias exposed some issues with this installing soegarots in
other places, so the plugin is also removed there.