### PR TITLE
Bugfix/dev 1624 storageos volume unmount deletes

### DIFF
--- a/acceptance-tests/cli/cli-volume.bats
+++ b/acceptance-tests/cli/cli-volume.bats
@@ -61,7 +61,7 @@ vol_prefix="$prefix storageos $cliopts volume"
   assert_success
 
   # add a regression for unmount deleting parent dir
-  run $prefix test -e /media
+  run $prefix test -e /media/testmount
   assert_success
 }
 

--- a/acceptance-tests/cli/cli-volume.bats
+++ b/acceptance-tests/cli/cli-volume.bats
@@ -49,15 +49,19 @@ vol_prefix="$prefix storageos $cliopts volume"
   assert_failure
 }
 
-@test "mount disk" {
+@test "mount disk" { # Should be re-enabled once node is also tested in BATS
   skip # currently know to fail due to mount propagation bug..
   run $vol_prefix mount $FULL_NAME /media/testmount
   assert_success
 }
 
-@test "unmount disk" {
+@test "unmount disk" { # Should be re-enabled once node is also tested in BATS
   skip # currently know to fail due to mount propagation bug..
   run $vol_prefix unmount $FULL_NAME
+  assert_success
+
+  # add a regression for unmount deleting parent dir
+  run $prefix test -e /media
   assert_success
 }
 


### PR DESCRIPTION
Adds a regression test for dev 1624. This test will run-able once the node installation is also available for testing in BATS. This feature doesn't work (is not desirable?) for the docker plugin