### PR TITLE
Automate deletion of dead digitalocean machines

### DIFF
--- a/do_delete_tagged_droplets.sh
+++ b/do_delete_tagged_droplets.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# Interactively delete volumes at Digitalocean, based on their tag.
+
+set -e -u
+
+progname="$(basename "$0")"
+doctl="doctl"
+doctl_json="$doctl -o json"
+jq="jq"
+jq_raw="$jq"
+
+function usage() {
+  echo "Usage: $progname [-f] [[TAG] ...]" >&2
+  exit 1
+}
+
+function doctl_check() {
+  if ! $doctl_json compute droplet list >/dev/null; then
+    echo "doctl command test failed - are you logged in ('doctl auth init') ?" >&2
+    exit 1
+  fi
+}
+
+function fetch_tags() {
+  local tags
+  tags="$($doctl_json compute droplet list | $jq_raw --raw-output '.[] | .tags[]' | sort | uniq)"
+  echo "$tags"
+}
+
+function delete_tag() {
+  local tag tagged_name name
+  tag="${1:-}"
+  if [ -z "$1" ]; then
+    echo "Function usage: ${FUNCNAME[0]} TAG" >&2
+    exit 1
+  fi
+  tagged_name="$($doctl_json compute droplet list --tag-name "$tag" | $jq_raw --raw-output '.[] | .name' | sort)"
+  for name in $tagged_name; do
+    echo "Deleting $name"
+    $doctl compute droplet rm -f "$name"
+  done
+}
+
+doctl_check
+
+force_mode=0
+if [ "${1:-}" = "-f" ]; then
+  force_mode=1
+  shift
+fi
+
+tags="$*"
+if [ -z "$tags" ]; then
+  tags=$(fetch_tags)
+fi
+
+for tag in $tags; do
+  if [ "$force_mode" -eq 1 ]; then
+    echo "Deleting $tag"
+    delete_tag "$tag"
+  else
+    read -rp "Delete droplets with tag '$tag'? [yn] " response
+    case "$response" in
+      [Yy]*)
+        delete_tag "$tag"
+        ;;
+      *)
+        echo "Did not delete droplets for tag '$tag'"
+        ;;
+    esac
+  fi
+done
+
+exit 0


### PR DESCRIPTION
André's PR copied from old repo: https://github.com/croomes/vol-test/pull/20

Run this script without parameters to get a list of tags and a prompt. Saying 'y' will delete all machines with that tag.

Running with '-f' will skip the prompt and delete everything. That is not always a safe thing to do, but it is convenient sometimes.