### PR TITLE
Hef/use alias for isntall

### DIFF
--- a/acceptance-tests/smoke/cli-1-virtual.bats
+++ b/acceptance-tests/smoke/cli-1-virtual.bats
@@ -13,7 +13,7 @@ load "../../test_helper"
   assert_line --partial "default/clivol"
 }
 
-@test "Confirm volume is created (docker volume ls) using driver ($driver)" {
+@test "Confirm volume is created (docker volume ls) using driver (storageos)" {
   run $prefix docker volume ls
   assert_line --partial "clivol"
 }
@@ -24,9 +24,9 @@ load "../../test_helper"
   assert_line --partial "\"status\": \"active"
 }
 
-@test "Confirm docker volume inspect works using driver ($driver)" {
+@test "Confirm docker volume inspect works using driver (storageos)" {
   run $prefix docker volume inspect clivol
-  assert_line --partial "\"Driver\": \"$driver"
+  assert_line --partial "\"Driver\": \"storageos:latest"
 }
 
 @test "Start a container and mount the volume" {

--- a/acceptance-tests/smoke/plugin-replication.bats
+++ b/acceptance-tests/smoke/plugin-replication.bats
@@ -2,12 +2,12 @@
 
 load ../../test_helper
 
-@test "Create replicated volume using driver ($driver)" {
-  run $prefix2 docker volume create --driver $driver $createopts --opt storageos.feature.replicas=1 repl-vol
+@test "Create replicated volume using driver (storageos)" {
+  run $prefix2 docker volume create --driver storageos $createopts --opt storageos.feature.replicas=1 repl-vol
   assert_success
 }
 
-@test "Confirm volume is created (volume ls) using driver ($driver)" {
+@test "Confirm volume is created (volume ls) using driver (storageos)" {
   run $prefix2 docker volume ls
   assert_line --partial "repl-vol"
 }
@@ -48,7 +48,7 @@ load ../../test_helper
 }
 
 @test "Stop storageos on node 2" {
-  run $prefix2 docker plugin disable -f $driver
+  run $prefix2 docker plugin disable -f storageos
   assert_success
 }
 
@@ -63,7 +63,7 @@ load ../../test_helper
 }
 
 @test "Re-start storageos on node 2" {
-  run $prefix2 docker plugin enable $driver
+  run $prefix2 docker plugin enable storageos
   assert_success
 }
 

--- a/docker-plugin/docker-tests/secondnode.bats
+++ b/docker-plugin/docker-tests/secondnode.bats
@@ -2,21 +2,21 @@
 
 load "../../test_helper"
 
-@test "Test: Install plugin for driver ($driver) on node 2" {
+@test "Test: Install plugin for driver (storageos) on node 2" {
   #skip "This test works, faster for rev without it"
-  run $prefix2 -t "docker plugin ls | grep $driver"
+  run $prefix2 -t "docker plugin ls | grep storageos"
   if [[ $status -eq 0 ]]; then
     skip
   fi
 
   run $prefix2 docker plugin disable storageos -f
   run $prefix2 docker plugin rm storageos
-  run $prefix2 docker plugin install --grant-all-permissions $driver $pluginopts
+  run $prefix2 docker plugin install --grant-all-permissions --alias storageos $driver $pluginopts
   sleep 60
   assert_success
 }
 
-@test "Test: Confirm volume is visible on second node (volume ls) using driver ($driver)" {
+@test "Test: Confirm volume is visible on second node (volume ls) using driver (storageos)" {
   run $prefix2 docker volume ls
   assert_line --partial "testvol"
 }

--- a/docker-plugin/docker-tests/singlenode.bats
+++ b/docker-plugin/docker-tests/singlenode.bats
@@ -2,33 +2,33 @@
 
 load "../../test_helper"
 
-@test "Test: Install plugin for driver ($driver)" {
+@test "Test: Install plugin " {
   #skip "Faster for rev during development without it - leave driver installed"
-  run $prefix -t "docker plugin ls | grep $driver"
+  run $prefix -t "docker plugin ls | grep storageos"
   if [[ $status -eq 0 ]]; then
     skip
   fi
 
   run $prefix docker plugin disable storageos -f
   run $prefix docker plugin rm storageos
-  run $prefix docker plugin install --grant-all-permissions $driver $pluginopts
+  run $prefix docker plugin install --grant-all-permissions --alias storageos $driver $pluginopts
   assert_success
   sleep 60
 }
 
-@test "Test: Create volume using driver ($driver)" {
-  run $prefix docker volume create --driver $driver $createopts testvol
+@test "Test: Create volume using driver (storageos)" {
+  run $prefix docker volume create --driver storageos $createopts testvol
   assert_success
 }
 
-@test "Test: Confirm volume is created (volume ls) using driver ($driver)" {
+@test "Test: Confirm volume is created (volume ls)" {
   run $prefix docker volume ls
   assert_line --partial "testvol"
 }
 
-@test "Test: Confirm docker volume inspect works using driver ($driver)" {
+@test "Test: Confirm docker volume inspect works using driver (storageos)" {
   run $prefix docker volume inspect testvol
-  assert_line --partial "\"Driver\": \"$driver"
+  assert_line --partial "\"Driver\": \"storageos:latest"
 }
 
 @test "Start a container and mount the volume" {

--- a/docker-plugin/install/clear_plugin.sh
+++ b/docker-plugin/install/clear_plugin.sh
@@ -2,12 +2,12 @@
 
 # shellcheck disable=SC2086
 
-driver=notset
+driver=storageos
 
 # shellcheck disable=SC1091 source=../../test.env
-. ../../test.sh
+. ../../test.env
 
-rm_plugin="docker plugin rm $driver"
+rm_plugin="docker plugin rm -f $driver"
 
 $PREFIX $rm_plugin
 $PREFIX2 $rm_plugin


### PR DESCRIPTION
This PR ensures that the alias driver is used everywhere.
This is a problem when running test manually currently depending on the order or running test.
this was masked in pipeline since the order is correct.

Note: It is a requirement to run with the storageos alias for the plugin.