### PR TITLE
Check downloaded binary

### DIFF
--- a/do_delete_tagged_droplets.sh
+++ b/do_delete_tagged_droplets.sh
@@ -8,7 +8,7 @@ progname="$(basename "$0")"
 doctl="doctl"
 doctl_json="$doctl -o json"
 jq="jq"
-jq_raw="$jq"
+jq_raw="$jq --raw-output"
 
 function usage() {
   echo "Usage: $progname [-f] [[TAG] ...]" >&2
@@ -24,7 +24,7 @@ function doctl_check() {
 
 function fetch_tags() {
   local tags
-  tags="$($doctl_json compute droplet list | $jq_raw --raw-output '.[] | .tags[]' | sort | uniq)"
+  tags="$($doctl_json compute droplet list | $jq_raw '.[] | select(.tags != null) | .tags[]' | sort | uniq)"
   echo "$tags"
 }
 
@@ -35,7 +35,7 @@ function delete_tag() {
     echo "Function usage: ${FUNCNAME[0]} TAG" >&2
     exit 1
   fi
-  tagged_id="$($doctl_json compute droplet list --tag-name "$tag" | $jq_raw --raw-output '.[] | .id' | sort)"
+  tagged_id="$($doctl_json compute droplet list --tag-name "$tag" | $jq_raw '.[] | .id' | sort)"
   for id in $tagged_id; do
     echo "Deleting $id"
     $doctl compute droplet rm -f "$id"

--- a/provision.sh
+++ b/provision.sh
@@ -78,6 +78,13 @@ function download_storageos_cli()
       curl --fail -sSL "https://github.com/storageos/go-cli/releases/download/${cli_version}/storageos_linux_amd64" > "$cli_binary"
       chmod +x "$cli_binary"
     fi
+
+    echo "Testing downloaded CLI using Docker"
+    if ! docker run -ti -v "$(pwd)":/mnt ubuntu:xenial /mnt/"$cli_binary" --help; then
+      echo "Failed to run storageos binary '$cli_binary'" >&2
+      exit 1
+    fi
+
   else
     # Build the binary.
     echo "Building CLI from source, branch ${cli_branch}"


### PR DESCRIPTION
Run the downloaded CLI via Docker to see if we downloaded it correctly.

The test isn't very smart, it just runs it and expects a shell exit 0. We couldn't use 'storageos version'; that looks for the server and fails because there isn't a server in this environment.

It is a great deal better than nothing, though.

_En passant_ fix a bug in do_delete_tagged_droplets.sh that doesn't choke on droplets without tags.