### PR TITLE
Don't request a tty, we might not get one

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -80,7 +80,7 @@ function download_storageos_cli()
     fi
 
     echo "Testing downloaded CLI using Docker"
-    if ! docker run -ti -v "$(pwd)":/mnt ubuntu:xenial /mnt/"$cli_binary" --help; then
+    if ! docker run -v "$(pwd)":/mnt ubuntu:xenial /mnt/"$cli_binary" --help; then
       echo "Failed to run storageos binary '$cli_binary'" >&2
       exit 1
     fi


### PR DESCRIPTION
Jenkins - correctly - doesn't provide a tty to run the script, so docker run -ti fails. So don't do that.