### PR TITLE
Update join.bats

### DIFF
--- a/node-join/join.bats
+++ b/node-join/join.bats
@@ -31,6 +31,9 @@ load ../test_helper
 
   run $prefix3 docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$(printf "%s:5705,%s:5705,%s:5705" "$AIP1" "AIP2" "AIP3")
   assert_success
+  
+  # Cluster joining takes a little time
+  sleep 10
 
   declare -a arr=("$prefix" "$prefix2" "$prefix3")
 


### PR DESCRIPTION
The cluster sometimes has not settled in this test, causing false failures.

This should fix the `API error (Service Unavailable): KV Store Unavailable` seen on some test runs.