### PR TITLE
Add wait commands

### DIFF
--- a/docker-plugin/docker-tests/secondnode.bats
+++ b/docker-plugin/docker-tests/secondnode.bats
@@ -12,8 +12,9 @@ load "../../test_helper"
   run $prefix2 docker plugin disable storageos -f
   run $prefix2 docker plugin rm storageos
   run $prefix2 docker plugin install --grant-all-permissions --alias storageos $driver $pluginopts
-  sleep 60
   assert_success
+
+  wait_for_volumes
 }
 
 @test "Test: Confirm volume is visible on second node (volume ls) using driver (storageos)" {

--- a/docker-plugin/docker-tests/singlenode.bats
+++ b/docker-plugin/docker-tests/singlenode.bats
@@ -13,7 +13,8 @@ load "../../test_helper"
   run $prefix docker plugin rm storageos
   run $prefix docker plugin install --grant-all-permissions --alias storageos $driver $pluginopts
   assert_success
-  sleep 60
+
+  wait_for_volumes
 }
 
 @test "Test: Create volume using driver (storageos)" {

--- a/node-join/install.bats
+++ b/node-join/install.bats
@@ -3,7 +3,6 @@
 # is this test up to date?
 load ../test_helper
 
-
 @test "IP list join [INSTALL]" {
   AIP1=$(echo $prefix | cut -f 2 -d'@')
   AIP2=$(echo $prefix2 | cut -f 2 -d'@')
@@ -32,7 +31,7 @@ load ../test_helper
     assert_success
   done
 
-  sleep 5
+  wait_for_cluster
 }
 
 @test "IP list join [VERIFY]" {
@@ -81,7 +80,7 @@ load ../test_helper
     assert_success
   done
 
-  sleep 5
+  wait_for_cluster
 }
 
 @test "IP list join no port [VERIFY]" {
@@ -126,7 +125,7 @@ load ../test_helper
     assert_success
   done
 
-  sleep 5
+  wait_for_cluster
 }
 
 @test "IP list join scheme [VERIFY]" {
@@ -171,7 +170,7 @@ load ../test_helper
     assert_success
   done
 
-  sleep 5
+  wait_for_cluster
 }
 
 @test "IP list join scheme no port [VERIFY]" {
@@ -216,7 +215,7 @@ load ../test_helper
     assert_success
   done
 
-  sleep 5
+  wait_for_cluster
 }
 
 @test "IP list join mixture [VERIFY]" {
@@ -261,8 +260,7 @@ load ../test_helper
     assert_success
   done
 
-  # Let the cluster settle
-  sleep 10
+  wait_for_cluster
 }
 
 @test "IP list join token [VERIFY]" {

--- a/node-join/join.bats
+++ b/node-join/join.bats
@@ -12,8 +12,7 @@ load ../test_helper
   run $prefix docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$join
   assert_success
 
-  # Need to do a long wait until DEV-1645 is fixed
-  sleep 30
+  wait_for_volumes 1
 }
 
 @test "join after volume create [VERIFY]" {
@@ -31,9 +30,8 @@ load ../test_helper
 
   run $prefix3 docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$(printf "%s:5705,%s:5705,%s:5705" "$AIP1" "AIP2" "AIP3")
   assert_success
-  
-  # Cluster joining takes a little time
-  sleep 10
+
+  wait_for_cluster
 
   declare -a arr=("$prefix" "$prefix2" "$prefix3")
 

--- a/test_helper.bash
+++ b/test_helper.bash
@@ -14,3 +14,48 @@ prefix3="$PREFIX3"
 createopts="$CREATEOPTS"
 pluginopts="$PLUGINOPTS"
 cliopts="$CLIOPTS"
+
+# Wait for the cluster to become available
+function wait_for_cluster {
+  no_of_nodes=${1:-"3"}
+  max_time=${2:-"30"}
+
+  printf "VARS %s %s\n" "$no_of_nodes" "$max_time"
+
+  for ((number=0;number < $max_time;number++))
+  {
+    sleep "1s"
+    health=$($prefix storageos -u storageos -p storageos cluster health --format '{{.KV}}{{.NATS}}{{.Scheduler}}') || true
+
+    # iff the command suceeds check the output
+    if [[ "$health" != "" ]]; then
+      # iff we can see all the nodes check the health
+      if [[ $(echo "$health" | wc -l) -eq $no_of_nodes ]]; then
+        ok=1
+
+        # Every line should start with 'Healthy'
+        while read -r line; do
+          if [[ "$line" != "alivealivealive" ]]; then
+            ok=0
+          fi
+        done <<< "$health"
+
+        # Iff all are healthy, return early
+        if [[ ok -eq 1 ]]; then
+          return 0
+        fi
+
+      fi
+    fi
+  }
+
+  # Timeout
+  return 0
+}
+
+# Wait for the cluster to be available and volumes are provisionable
+function wait_for_volumes {
+    wait_for_cluster $1
+    sleep "15s" # CP has a safety sleep on newly provisioned nodes
+    return 0
+}


### PR DESCRIPTION
Add wait_for_cluster and wait_for_volumes utility functions.
These should reduce unnecessary sleeping and aid stability.
Calling these functions conveys intent better than sleeping in tests.

This has been tested locally