### PR TITLE
Test timeouts

### DIFF
--- a/acceptance-tests/cli/cli-cluster.bats
+++ b/acceptance-tests/cli/cli-cluster.bats
@@ -2,24 +2,27 @@
 
 load ../../test_helper
 
+short_run="run ui_timeout"
+long_run="run long_timeout"
+
 @test "create cluster with defaults" {
-  run $prefix storageos $cliopts cluster create
+  $short_run $prefix storageos $cliopts cluster create
   assert_success
   echo $output | egrep '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
   assert_success
-  run $prefix storageos $cliopts cluster rm $output
+  $short_run $prefix storageos $cliopts cluster rm $output
   assert_success
 }
 
 @test "create cluster with valid size (3)" {
-  run $prefix storageos $cliopts cluster create -s 3
+  $short_run $prefix storageos $cliopts cluster create -s 3
   assert_success
-  run $prefix storageos $cliopts cluster rm $output
+  $short_run $prefix storageos $cliopts cluster rm $output
   assert_success
 }
 
 @test "create cluster with invalid size (4)" {
-  run $prefix storageos $cliopts cluster create -s 4
+  $short_run $prefix storageos $cliopts cluster create -s 4
   assert_failure
 
   # No need to remove, they shouldn't exist, and $output won't be ID's
@@ -30,51 +33,51 @@ load ../../test_helper
 }
 
 @test "delete cluster" {
-  run $prefix storageos $cliopts cluster create
+  $short_run $prefix storageos $cliopts cluster create
   assert_success
-  run $prefix storageos $cliopts cluster rm $output
+  $short_run $prefix storageos $cliopts cluster rm $output
   assert_success
-  run $prefix storageos $cliopts cluster inspect $output
+  $short_run $prefix storageos $cliopts cluster inspect $output
   assert_failure
 }
 
 @test "cluster inspect with defaults" {
-  run $prefix storageos $cliopts cluster create
+  $short_run $prefix storageos $cliopts cluster create
   id=$output
-  run $prefix storageos $cliopts cluster inspect $id
-  run $prefix storageos $cliopts cluster inspect $id --format {{.ID}}
+  $short_run $prefix storageos $cliopts cluster inspect $id
+  $short_run $prefix storageos $cliopts cluster inspect $id --format {{.ID}}
   assert_output $id
-  run $prefix storageos $cliopts cluster inspect $id --format {{.Size}}
+  $short_run $prefix storageos $cliopts cluster inspect $id --format {{.Size}}
   assert_output 3
-  run $prefix storageos $cliopts cluster rm $id
+  $short_run $prefix storageos $cliopts cluster rm $id
   assert_success
 }
 
 @test "cluster health before nodes joined using cluster id" {
-  run $prefix storageos $cliopts cluster create
-  run $prefix storageos $cliopts cluster health $output
+  $short_run $prefix storageos $cliopts cluster create
+  $short_run $prefix storageos $cliopts cluster health $output
   assert_failure
   assert_output "No cluster nodes found"
 }
 
 @test "cluster health existing cluster using bad api" {
-  run $prefix STORAGEOS_HOST=999.999.999.999 storageos $cliopts cluster health
+  $short_run $prefix STORAGEOS_HOST=999.999.999.999 storageos $cliopts cluster health
   assert_failure
   assert_output "API not responding to list nodes: Get http://999.999.999.999:5705/version: dial tcp: lookup 999.999.999.999: no such host"
 }
 
 @test "cluster health existing cluster using api" {
-  run $prefix storageos $cliopts cluster health
+  $short_run $prefix storageos $cliopts cluster health
   assert_success
 }
 
 @test "cluster health existing cluster using api" {
-  run $prefix storageos $cliopts cluster health
+  $short_run $prefix storageos $cliopts cluster health
   assert_success
 }
 
 @test "cluster health default format" {
-  run $prefix storageos $cliopts cluster health
+  $short_run $prefix storageos $cliopts cluster health
   assert_success
   assert_output --partial "KV"
   assert_output --partial "NATS"
@@ -87,7 +90,7 @@ load ../../test_helper
 }
 
 @test "cluster health cp format" {
-  run $prefix storageos $cliopts cluster health --format cp
+  $short_run $prefix storageos $cliopts cluster health --format cp
   assert_success
   assert_output --partial "KV"
   assert_output --partial "KV_WRITE"
@@ -96,7 +99,7 @@ load ../../test_helper
 }
 
 @test "cluster health dp format" {
-  run $prefix storageos $cliopts cluster health --format dp
+  $short_run $prefix storageos $cliopts cluster health --format dp
   assert_success
   assert_output --partial "DFS_CLIENT"
   assert_output --partial "DFS_SERVER"
@@ -106,31 +109,31 @@ load ../../test_helper
 }
 
 @test "cluster health quiet" {
-  run $prefix storageos $cliopts cluster health --quiet
+  $short_run $prefix storageos $cliopts cluster health --quiet
   assert_success
 }
 
 @test "cluster health quiet cp format" {
-  run $prefix storageos $cliopts cluster health --format cp --quiet
+  $short_run $prefix storageos $cliopts cluster health --format cp --quiet
   assert_success
 }
 
 @test "cluster health quiet dp format" {
-  run $prefix storageos $cliopts cluster health --format dp --quiet
+  $short_run $prefix storageos $cliopts cluster health --format dp --quiet
   assert_success
 }
 
 @test "cluster health raw format" {
-  run $prefix storageos $cliopts cluster health --format raw
+  $short_run $prefix storageos $cliopts cluster health --format raw
   assert_success
 }
 
 @test "cluster health quiet raw format" {
-  run $prefix storageos $cliopts cluster health --format raw --quiet
+  $short_run $prefix storageos $cliopts cluster health --format raw --quiet
   assert_success
 }
 
 @test "cluster health custom format" {
-  run $prefix storageos $cliopts cluster health --format {{.Node}}
+  $short_run $prefix storageos $cliopts cluster health --format {{.Node}}
   assert_success
 }

--- a/acceptance-tests/cli/cli-config.bats
+++ b/acceptance-tests/cli/cli-config.bats
@@ -2,13 +2,16 @@
 
 load ../../test_helper
 
+short_run="run ui_timeout"
+long_run="run long_timeout"
+
 @test "auth - incorrect user not allowed" {
-  run $prefix storageos -u wrong-user volume ls
+  $short_run $prefix storageos -u wrong-user volume ls
   refute [[ $status -eq 0 ]]
 }
 
 @test "auth - incorrect pass not allowed" {
-  run $prefix storageos -p wrong-pass volume ls
+  $short_run $prefix storageos -p wrong-pass volume ls
   refute [[ $status -eq 0 ]]
 }
 

--- a/acceptance-tests/cli/cli-login.bats
+++ b/acceptance-tests/cli/cli-login.bats
@@ -2,22 +2,25 @@
 
 load ../../test_helper
 
+short_run="run ui_timeout"
+long_run="run long_timeout"
+
 @test "test cli login" {
   # Should fail as there are no creds set
-  run $prefix storageos volume ls
+  $short_run $prefix storageos volume ls
   assert_failure
 
-  run $prefix storageos login localhost --username storageos --password storageos
+  $short_run $prefix storageos login localhost --username storageos --password storageos
   assert_success
 
   # Should work as there are cached creds
-  run $prefix storageos volume ls
+  $short_run $prefix storageos volume ls
   assert_success
 
-  run $prefix storageos logout localhost
+  $short_run $prefix storageos logout localhost
   assert_success
 
   # Should fail as there are no creds set
-  run $prefix storageos volume ls
+  $short_run $prefix storageos volume ls
   assert_failure
 }

--- a/acceptance-tests/cli/cli-namespace.bats
+++ b/acceptance-tests/cli/cli-namespace.bats
@@ -2,6 +2,9 @@
 
 load ../../test_helper
 
+short_run="run ui_timeout"
+long_run="run long_timeout"
+
 export NAMESPACE=test-namespace
 export DESCRIPTION="descriptionfornamespacesuite"
 
@@ -9,85 +12,85 @@ namespace_prefix="$prefix storageos $cliopts namespace"
 
 
 @test "create namespace w description" {
-  run $namespace_prefix create -d \'$DESCRIPTION\' $NAMESPACE
+  $short_run $namespace_prefix create -d \'$DESCRIPTION\' $NAMESPACE
   assert_success
 }
 
 @test "create namespace - already exists" {
-  run $namespace_prefix create $NAMESPACE
+  $short_run $namespace_prefix create $NAMESPACE
   assert_failure
 }
 
 @test "create namespace - no name" {
-  run $namespace_prefix create
+  $short_run $namespace_prefix create
   assert_failure
 }
 
 @test "create namespace - non-admin" {
-  run $prefix storageos $cliopts user create awesomeUser --password foobar123
+  $short_run $prefix storageos $cliopts user create awesomeUser --password foobar123
   assert_success
 
-  run $prefix storageos -u awesomeUser -p foobar123 namespace create
+  $short_run $prefix storageos -u awesomeUser -p foobar123 namespace create
   assert_failure
 
-  run $prefix storageos $cliopts user rm awesomeUser
+  $short_run $prefix storageos $cliopts user rm awesomeUser
   assert_success
 }
 
 @test "can create disk in namespace" {
-  run $prefix storageos $cliopts volume create -n $NAMESPACE test
+  $short_run $prefix storageos $cliopts volume create -n $NAMESPACE test
   assert_success
 }
 
 @test "cannot create same disk in same namespace" {
-  run $prefix storageos $cliopts volume create -n $NAMESPACE test
+  $short_run $prefix storageos $cliopts volume create -n $NAMESPACE test
   assert_failure
 }
 
 @test "can create/delete disk in other namespace" {
-  run $prefix storageos $cliopts volume create -n "other" test
+  $short_run $prefix storageos $cliopts volume create -n "other" test
   assert_success
-  run $prefix storageos $cliopts volume rm other/test
+  $short_run $prefix storageos $cliopts volume rm other/test
   assert_success
 }
 
 @test "inspect namespace" {
   # description is not used..
-  run $namespace_prefix inspect $NAMESPACE
+  $short_run $namespace_prefix inspect $NAMESPACE
   echo $output | jq 'first.name == "test-namespace"'
   echo $output | jq 'first.description == "description for namespace suite"'
 }
 
 @test "second node can see namespace" {
-  run $prefix2 storageos $cliopts namespace inspect $NAMESPACE
+  $short_run $prefix2 storageos $cliopts namespace inspect $NAMESPACE
   echo $output | jq 'first.name == "test-namespace"'
   echo $output | jq 'first.description == "description for namespace suite"'
 }
 
 @test "list namespace" {
-  run $namespace_prefix ls
+  $short_run $namespace_prefix ls
   assert_output --partial $NAMESPACE
   assert_output --partial $DESCRIPTION
 }
 
 @test "update description" {
-  run $namespace_prefix update $NAMESPACE --description \'new description\'
+  $short_run $namespace_prefix update $NAMESPACE --description \'new description\'
   assert_success
-  run $namespace_prefix inspect $NAMESPACE
+  $short_run $namespace_prefix inspect $NAMESPACE
   echo $output | jq 'first.description == "new description"'
 }
 
 @test "update display name" {
-  run $namespace_prefix update $NAMESPACE --display-name "short"
+  $short_run $namespace_prefix update $NAMESPACE --display-name "short"
   assert_success
-  run $namespace_prefix inspect $NAMESPACE
+  $short_run $namespace_prefix inspect $NAMESPACE
   echo $output | jq 'first.displayName == "short"'
 }
 
 @test "delete namespace" {
-  run $namespace_prefix rm $NAMESPACE
+  $short_run $namespace_prefix rm $NAMESPACE
   assert_success
-  run $namespace_prefix rm other
+  $short_run $namespace_prefix rm other
   run '$namespace_prefix ls | grep -e $NAMESPACE -e other'
   assert_failure
 }

--- a/acceptance-tests/cli/cli-policies.bats
+++ b/acceptance-tests/cli/cli-policies.bats
@@ -2,33 +2,36 @@
 
 load ../../test_helper
 
+short_run="run ui_timeout"
+long_run="run long_timeout"
+
 @test "create policy" {
-  run $prefix storageos $cliopts user create policyTestUser --role user --password policiesAreCool
+  $short_run $prefix storageos $cliopts user create policyTestUser --role user --password policiesAreCool
   assert_success
 
-  run $prefix storageos $cliopts user create policyTestGroupUser --role user --password policiesAreCool --groups policyTestGroup
+  $short_run $prefix storageos $cliopts user create policyTestGroupUser --role user --password policiesAreCool --groups policyTestGroup
   assert_success
 
-  run $prefix storageos $cliopts namespace create policytestnamespace
+  $short_run $prefix storageos $cliopts namespace create policytestnamespace
   assert_success
 
-  run $prefix storageos $cliopts policy create --user policyTestUser --namespace policytestnamespace
+  $short_run $prefix storageos $cliopts policy create --user policyTestUser --namespace policytestnamespace
   assert_success
 
-  run $prefix storageos $cliopts policy create --group policyTestGroup --namespace policytestnamespace
+  $short_run $prefix storageos $cliopts policy create --group policyTestGroup --namespace policytestnamespace
   assert_success
 }
 
 @test "policy enforcement" {
-  run $prefix storageos $cliopts user create unprivileged --role user --password policiesAreCool
+  $short_run $prefix storageos $cliopts user create unprivileged --role user --password policiesAreCool
   assert_success
 
-  run $prefix storageos -u unprivileged -p policiesAreCool volume create myVol --namespace policytestnamespace
+  $short_run $prefix storageos -u unprivileged -p policiesAreCool volume create myVol --namespace policytestnamespace
   assert_failure
 
-  run $prefix storageos -u policyTestUser -p policiesAreCool volume create myVol --namespace policytestnamespace
+  $short_run $prefix storageos -u policyTestUser -p policiesAreCool volume create myVol --namespace policytestnamespace
   assert_success
 
-  run $prefix storageos -u policyTestGroupUser -p policiesAreCool volume create myOtherVol --namespace policytestnamespace
+  $short_run $prefix storageos -u policyTestGroupUser -p policiesAreCool volume create myOtherVol --namespace policytestnamespace
   assert_success
 }

--- a/acceptance-tests/cli/cli-pool.bats
+++ b/acceptance-tests/cli/cli-pool.bats
@@ -2,6 +2,9 @@
 
 load ../../test_helper
 
+short_run="run ui_timeout"
+long_run="run long_timeout"
+
 export POOL1=pool1
 export POOL1_3=pool13
 export DESCRIPTION="pool test suite"
@@ -13,52 +16,52 @@ export NAMESPACE="test"
 pool_prefix="$prefix storageos $cliopts pool"
 
 @test "create pool w description for node 1, bogus driver, controller (no check)" {
-  run $pool_prefix create -d \'$DESCRIPTION\' --drivers quantumdriver --controllers $NODE1 --controllers "bogus" $POOL1
+  $short_run $pool_prefix create -d \'$DESCRIPTION\' --drivers quantumdriver --controllers $NODE1 --controllers "bogus" $POOL1
   assert_success
 }
 
 @test "create pool - already exists" {
-  run $pool_prefix create $POOL
+  $short_run $pool_prefix create $POOL
   assert_failure
 }
 
 @test "create pool - no name" {
-  run $pool_prefix create
+  $short_run $pool_prefix create
   assert_failure
 }
 
 @test "can make pool for node 1 and 3" {
-  run $pool_prefix create -d \'$DESCRIPTION\' --drivers filesystem --controllers "$NODE1" --controllers "$NODE3" $POOL1_3
+  $short_run $pool_prefix create -d \'$DESCRIPTION\' --drivers filesystem --controllers "$NODE1" --controllers "$NODE3" $POOL1_3
   assert_success
 }
 
 @test "inspect pools" {
   # description is not used..
-  run $pool_prefix inspect $POOL1
+  $short_run $pool_prefix inspect $POOL1
   echo $output | jq "first.name == \"$POOL1\""
   echo $output | jq 'first.driver == "quantumdriver"'
   echo $output | jq 'first.controllers | length == 2'
 }
 
 @test "create 2 replica volume in pool1_3, it should have reject disk creation" {
-  run $prefix3 storageos $cliopts volume create -n $NAMESPACE -p $POOL1_3 --label 'storageos.feature.replicas=2' "2replicavolume"
+  $short_run $prefix3 storageos $cliopts volume create -n $NAMESPACE -p $POOL1_3 --label 'storageos.feature.replicas=2' "2replicavolume"
   assert_failure
 }
 
 @test "list pool" {
-  run $pool_prefix ls
+  $short_run $pool_prefix ls
   assert_output --partial $POOL1
   assert_output --partial $POOL1_3
   assert_output --partial $DESCRIPTION
 }
 
 @test "delete pools" {
-  $prefix storageos $cliopts volume rm $NAMESPACE/2replicavolume
-  $prefix storageos $cliopts namespace rm test
+  ui_timeout $prefix storageos $cliopts volume rm $NAMESPACE/2replicavolume
+  ui_timeout $prefix storageos $cliopts namespace rm test
 
-  run $pool_prefix rm $POOL1
+  $short_run $pool_prefix rm $POOL1
   assert_success
-  run $pool_prefix rm $POOL1_3
-  run "$pool_prefix ls | grep -e $POOL1 -e $POOL1_3"
+  $short_run $pool_prefix rm $POOL1_3
+  $short_run "$pool_prefix ls | grep -e $POOL1 -e $POOL1_3"
   assert_failure
 }

--- a/acceptance-tests/cli/cli-rules.bats
+++ b/acceptance-tests/cli/cli-rules.bats
@@ -2,6 +2,9 @@
 
 load ../../test_helper
 
+short_run="run ui_timeout"
+long_run="run long_timeout"
+
 export NAMESPACE=test
 export NAMESPACE_WRONG=test2
 
@@ -23,33 +26,33 @@ vol_prefix="$prefix storageos $cliopts volume"
 
 
 @test "create rule no namespace" {
-  run $rule_prefix create test-no-namespace --label app=xx
+  $short_run $rule_prefix create test-no-namespace --label app=xx
 
   # uses default namespace
   assert_success
 }
 
 @test "create replicator rule for repl=true" {
-	run $rule_prefix create -d \'a simple rule that replicates\' \
+	$short_run $rule_prefix create -d \'a simple rule that replicates\' \
 		--namespace "$NAMESPACE" --selector 'repl=true' --action add \
 		--label storageos.feature.replicas=1 "$REPL_RULE_NAME"
 	assert_success
 }
 
 @test "add norepl rule" {
-	run $rule_prefix create -d \'a rule for no replication in test namespace\' \
+	$short_run $rule_prefix create -d \'a rule for no replication in test namespace\' \
 		--namespace $NAMESPACE --selector 'no-repl=true' --action remove \
 		--label storageos.feature.replicas=1 "$NO_REPL_RULE_NAME"
 	assert_success
 }
 
 @test "attach norepl namespace label to $NAMESPACE" {
-	run $prefix storageos $cliopts namespace update --label-add "no-repl=true" "$NAMESPACE"
+	$short_run $prefix storageos $cliopts namespace update --label-add "no-repl=true" "$NAMESPACE"
 	assert_success
 }
 
 @test "create volume in namespace $NAMESPACE, rule is applied" {
-	run $vol_prefix create -n "$NAMESPACE" "$VOL1"
+	$short_run $vol_prefix create -n "$NAMESPACE" "$VOL1"
 	assert_success
 	run $vol_prefix inspect "$NAMESPACE/$VOL1"
 	echo $output | jq "first.labels | contains({\"no-repl\":\"true\"})"
@@ -57,37 +60,37 @@ vol_prefix="$prefix storageos $cliopts volume"
 }
 
 @test "create test volume in $NAMESPACE namespace with repl=true label" {
-	run $vol_prefix create -n "$NAMESPACE" "$VOL2" --label 'repl=true'
+	$short_run $vol_prefix create -n "$NAMESPACE" "$VOL2" --label 'repl=true'
 	assert_success
 }
 
 @test "namespace label should have precedence" {
-	run $prefix storageos $cliopts volume inspect "$NAMESPACE/$VOL2"
+	$short_run $prefix storageos $cliopts volume inspect "$NAMESPACE/$VOL2"
 	echo $output | jq 'first.labels | contains({"no-repl":"true"})'
 	echo $output | jq 'first.labels | contains({"storageos.feature.replicas":"1"}) | not'
 }
 
 @test "add same rule high priority in diff namespace" {
-	run $rule_prefix create -n "$NAMESPACE_WRONG" --selector 'no-repl=true' --action add \
+	$short_run $rule_prefix create -n "$NAMESPACE_WRONG" --selector 'no-repl=true' --action add \
 		--label namespace=different "$NO_REPL_RULE_NAME"
 	assert_success
 }
 
 @test "deactivate rule, removes replication label" {
-	run $rule_prefix update  --active=false "$FREPL_RULE_NAME"
+	$short_run $rule_prefix update  --active=false "$FREPL_RULE_NAME"
 	assert_success
 	run $vol_prefix create -n "$NAMESPACE" "$VOL4" --label 'repl=true'
 	assert_success
 }
 
 @test "list rules" {
-	run $rule_prefix ls
+	$short_run $rule_prefix ls
 	assert_output --partial "$NO_REPL_RULE_NAME"
 	assert_output --partial "$REPL_RULE_NAME"
 }
 
 @test "inspect rule" {
-	run $rule_prefix inspect "$FREPL_RULE_NAME"
+	$short_run $rule_prefix inspect "$FREPL_RULE_NAME"
 	echo $output | jq "first.name == \"$REPL_RULE_NAME\""
 	echo $output | jq "first.namespace == \"$NAMESPACE\""
 	echo $output | jq "first.weight == \"10\""
@@ -95,20 +98,19 @@ vol_prefix="$prefix storageos $cliopts volume"
 }
 
 @test "create rule defaults" {
-  run $rule_prefix create test-defaults -n default --label app=xx
+  $short_run $rule_prefix create test-defaults -n default --label app=xx
   assert_success
   run $rule_prefix inspect default/test-defaults
   echo $output | jq "first.weight == \"4\""
 }
 
 @test "delete rules and volume" {
-	run $rule_prefix rm $FNO_REPL_RULE_NAME
-	run $rule_prefix rm $FREPL_RULE_NAME
+	$short_run $rule_prefix rm $FNO_REPL_RULE_NAME
+	$short_run $rule_prefix rm $FREPL_RULE_NAME
 
 
-	$prefix storageos $cliopts namespace rm $NAMESPACE_WRONG
-	$prefix storageos $cliopts namespace rm $NAMESPACE
+	ui_timeout $prefix storageos $cliopts namespace rm $NAMESPACE_WRONG
+	ui_timeout $prefix storageos $cliopts namespace rm $NAMESPACE
 
-	run $rule_prefix rm default/test-defaults
-
+	$short_run $rule_prefix rm default/test-defaults
 }

--- a/acceptance-tests/cli/cli-users.bats
+++ b/acceptance-tests/cli/cli-users.bats
@@ -2,17 +2,20 @@
 
 load ../../test_helper
 
+short_run="run ui_timeout"
+long_run="run long_timeout"
+
 @test "create user - bad password" {
   # Should fail as passwords > 8 chars
-  run $prefix storageos $cliopts user create awesomeUser --password foo
+  $short_run $prefix storageos $cliopts user create awesomeUser --password foo
   assert_failure
 }
 
 @test "create user" {
-  run $prefix storageos $cliopts user create awesomeUser --role user --groups foo,bar --password foobar123
+  $short_run $prefix storageos $cliopts user create awesomeUser --role user --groups foo,bar --password foobar123
   assert_success
 
-  run $prefix storageos $cliopts user inspect awesomeUser
+  $short_run $prefix storageos $cliopts user inspect awesomeUser
   assert_success
 
   echo $output | jq '.[0].username == "awesomeUser"'
@@ -21,10 +24,10 @@ load ../../test_helper
 }
 
 @test "update user" {
-  run $prefix storageos $cliopts user update awesomeUser --role admin --remove-groups foo,bar --add-groups baz,bang
+  $short_run $prefix storageos $cliopts user update awesomeUser --role admin --remove-groups foo,bar --add-groups baz,bang
   assert_success
 
-  run $prefix storageos $cliopts user inspect awesomeUser
+  $short_run $prefix storageos $cliopts user inspect awesomeUser
   assert_success
 
   echo $output | jq '.[0].groups == "baz,bang"'
@@ -32,22 +35,22 @@ load ../../test_helper
 }
 
 @test "delete user" {
-  run $prefix storageos $cliopts user inspect awesomeUser
+  $short_run $prefix storageos $cliopts user inspect awesomeUser
   echo $output
 
-  run $prefix storageos $cliopts user rm awesomeUser
+  $short_run $prefix storageos $cliopts user rm awesomeUser
   assert_success
 
-  run $prefix storageos $cliopts user inspect awesomeUser
+  $short_run $prefix storageos $cliopts user inspect awesomeUser
   assert_failure
 }
 
 @test "create admin" {
-  run $prefix storageos $cliopts user create awesomeAdmin --role admin --groups foo,bar --password foobar123
+  $short_run $prefix storageos $cliopts user create awesomeAdmin --role admin --groups foo,bar --password foobar123
   echo $output
   assert_success
 
-  run $prefix storageos $cliopts user inspect awesomeAdmin
+  $short_run $prefix storageos $cliopts user inspect awesomeAdmin
   assert_success
 
   echo $output | jq '.[0].username == "awesomeAdmin"'
@@ -56,10 +59,10 @@ load ../../test_helper
 }
 
 @test "update admin" {
-  run $prefix storageos $cliopts user update awesomeAdmin --role user --remove-groups foo,bar --add-groups baz,bang
+  $short_run $prefix storageos $cliopts user update awesomeAdmin --role user --remove-groups foo,bar --add-groups baz,bang
   assert_success
 
-  run $prefix storageos $cliopts user inspect awesomeAdmin
+  $short_run $prefix storageos $cliopts user inspect awesomeAdmin
   assert_success
 
   echo $output | jq '.[0].groups == "baz,bang"'
@@ -67,9 +70,9 @@ load ../../test_helper
 }
 
 @test "delete admin" {
-  run $prefix storageos $cliopts user rm awesomeAdmin
+  $short_run $prefix storageos $cliopts user rm awesomeAdmin
   assert_success
 
-  run $prefix storageos $cliopts user inspect awesomeAdmin
+  $short_run $prefix storageos $cliopts user inspect awesomeAdmin
   assert_failure
 }

--- a/acceptance-tests/cli/cli-volume.bats
+++ b/acceptance-tests/cli/cli-volume.bats
@@ -2,6 +2,9 @@
 
 load ../../test_helper
 
+short_run="run ui_timeout"
+long_run="run long_timeout"
+
 export VOL_NAME=vol1
 export NAMESPACE=test
 export FULL_NAME=$NAMESPACE/$VOL_NAME
@@ -10,13 +13,13 @@ vol_prefix="$prefix storageos $cliopts volume"
 
 @test "create disk with size, description and fstype" {
   # awaiting bug fix for description: DEV-1238
-  run $vol_prefix create  -f reiserfs -d \'1Gb disk for disk create tests\' -s 1 -n $NAMESPACE $VOL_NAME
+  $short_run $vol_prefix create  -f reiserfs -d \'1Gb disk for disk create tests\' -s 1 -n $NAMESPACE $VOL_NAME
   assert_success
   assert_output $FULL_NAME
 }
 
 @test "create disk - no name" {
-  run $vol_prefix create -n $NAMESPACE
+  $short_run $vol_prefix create -n $NAMESPACE
   assert_failure
   # current error message is bad.. should be stopped at cli and not return from api
   # message should contain please provide name for disk :
@@ -24,19 +27,19 @@ vol_prefix="$prefix storageos $cliopts volume"
 }
 
 @test "create disk -  no namespace" {
-  run $vol_prefix create nonamespace
+  $short_run $vol_prefix create nonamespace
   # uses default namespace
   assert_success
 }
 
 @test "create disk - already exists in namespace" {
-  run $vol_prefix create  -n $NAMESPACE -s 1 $VOL_NAME
+  $short_run $vol_prefix create  -n $NAMESPACE -s 1 $VOL_NAME
   assert_failure
   assert_output --partial "Volume with name '$VOL_NAME' already exists"
 }
 
 @test "inspect disk " {
-  run $vol_prefix inspect $FULL_NAME
+  $short_run $vol_prefix inspect $FULL_NAME
   echo $output | jq 'first.namespace == "test"'
   echo $output | jq 'first.fsType == "reiserfs"'
   echo $output | jq "first.name == \"$VOL_NAME\""
@@ -45,19 +48,19 @@ vol_prefix="$prefix storageos $cliopts volume"
 }
 
 @test "inspect - no disk" {
-  run $vol_prefix inspect
+  $short_run $vol_prefix inspect
   assert_failure
 }
 
 @test "mount disk" { # Should be re-enabled once node is also tested in BATS
   skip # currently know to fail due to mount propagation bug..
-  run $vol_prefix mount $FULL_NAME /media/testmount
+  $long_run $vol_prefix mount $FULL_NAME /media/testmount
   assert_success
 }
 
 @test "unmount disk" { # Should be re-enabled once node is also tested in BATS
   skip # currently know to fail due to mount propagation bug..
-  run $vol_prefix unmount $FULL_NAME
+  $long_run $vol_prefix unmount $FULL_NAME
   assert_success
 
   # add a regression for unmount deleting parent dir
@@ -66,23 +69,23 @@ vol_prefix="$prefix storageos $cliopts volume"
 }
 
 @test "update - size to 2gb" {
-  run $vol_prefix update -s 2 $FULL_NAME
-  run $vol_prefix inspect $FULL_NAME
+  $short_run $vol_prefix update -s 2 $FULL_NAME
+  $short_run $vol_prefix inspect $FULL_NAME
   echo $output | jq 'first.size == 2'
 }
 
 @test "update - size 0" {
-  run $vol_prefix update -s 0 $FULL_NAME
+  $short_run $vol_prefix update -s 0 $FULL_NAME
   assert_failure
 }
 
 @test "update - size negative" {
-  run $vol_prefix update -s -1 $FULL_NAME
+  $short_run $vol_prefix update -s -1 $FULL_NAME
   assert_failure
 }
 
 @test "delete disk" {
-  run $vol_prefix rm $FULL_NAME
+  $short_run $vol_prefix rm $FULL_NAME
   assert_success
 }
 

--- a/acceptance-tests/smoke/cli-1-virtual.bats
+++ b/acceptance-tests/smoke/cli-1-virtual.bats
@@ -2,76 +2,79 @@
 
 load "../../test_helper"
 
+short_run="run ui_timeout"
+long_run="run long_timeout"
+
 # Basic
 @test "Create volume using storageos cli" {
-  run $prefix storageos $cliopts volume create -n default clivol
+  $short_run $prefix storageos $cliopts volume create -n default clivol
   assert_success
 }
 
 @test "Confirm volume is created (storageos volume ls) using storageos cli" {
-  run $prefix storageos $cliopts volume ls
+  $short_run $prefix storageos $cliopts volume ls
   assert_line --partial "default/clivol"
 }
 
 @test "Confirm volume is created (docker volume ls)" {
-  run $prefix docker volume ls
+  $short_run $prefix docker volume ls
   assert_line --partial "clivol"
 }
 
 @test "Confirm volume inspect works using storageos cli" {
-  run $prefix storageos $cliopts volume inspect default/clivol
+  $short_run $prefix storageos $cliopts volume inspect default/clivol
   assert_line --partial "\"name\": \"clivol"
   assert_line --partial "\"status\": \"active"
 }
 
 @test "Confirm docker volume inspect works" {
-  run $prefix docker volume inspect clivol
+  $short_run $prefix docker volume inspect clivol
   assert_line --partial "\"Driver\": \"storageos:latest"
 }
 
 @test "Start a container and mount the volume" {
-  run $prefix docker run -i -d --name mounter -v clivol:/data ubuntu /bin/bash
+  $long_run $prefix docker run -i -d --name mounter -v clivol:/data ubuntu /bin/bash
   assert_success
 }
 
 @test "Write a textfile to the volume" {
-  run $prefix 'docker exec -i -d mounter /bin/bash -c "echo \"testdata\" > /data/foo.txt"'
+  $short_run $prefix 'docker exec -i -d mounter /bin/bash -c "echo \"testdata\" > /data/foo.txt"'
   assert_success
 }
 
 @test "Confirm textfile contents on the volume" {
-  run $prefix docker exec -i mounter cat /data/foo.txt
+  $short_run $prefix docker exec -i mounter cat /data/foo.txt
   assert_line --partial "testdata"
 }
 
 @test "Stop container" {
-  run $prefix docker stop mounter
+  $long_run $prefix docker stop mounter
   assert_success
 }
 
 @test "Destroy container" {
-  run $prefix docker rm mounter
+  $long_run $prefix docker rm mounter
   assert_success
 }
 
 @test "Remove volume using storageos cli" {
-  run $prefix storageos $cliopts volume rm default/clivol
+  $short_run $prefix storageos $cliopts volume rm default/clivol
   assert_success
 }
 
 @test "Confirm volume is removed using storageos cli" {
-  run $prefix storageos $cliopts volume ls
+  $short_run $prefix storageos $cliopts volume ls
   refute_output --partial 'default/clivol'
 }
 
 # Create options
 @test "Create volume using storageos cli with options" {
-  run $prefix storageos $cliopts volume create -n default --size 1 --label env=test --label org=dev --description \"test vol\" clivol
+  $short_run $prefix storageos $cliopts volume create -n default --size 1 --label env=test --label org=dev --description \"test vol\" clivol
   assert_success
 }
 
 @test "Confirm volume inspect works using storageos cli (create with options)" {
-  run $prefix storageos $cliopts volume inspect default/clivol
+  $short_run $prefix storageos $cliopts volume inspect default/clivol
   assert_line --partial "\"name\": \"clivol\""
   assert_line --partial "\"description\": \"test vol"\"
   assert_line --partial "\"env\": \"test"\"
@@ -81,23 +84,23 @@ load "../../test_helper"
 }
 
 @test "Remove volume with options using storageos cli" {
-  run $prefix storageos $cliopts volume rm default/clivol
+  $short_run $prefix storageos $cliopts volume rm default/clivol
   assert_success
 }
 
 # Update
 @test "Create basic volume using storageos cli" {
-  run $prefix storageos $cliopts volume create -n default clivol
+  $short_run $prefix storageos $cliopts volume create -n default clivol
   assert_success
 }
 
 @test "Update basic volume using storageos cli" {
-  run $prefix storageos $cliopts volume update --size 10 --label-add env=test --label-add org=dev --description \"test vol\" default/clivol
+  $short_run $prefix storageos $cliopts volume update --size 10 --label-add env=test --label-add org=dev --description \"test vol\" default/clivol
   assert_success
 }
 
 @test "Confirm volume inspect sees updated values using storageos cli" {
-  run $prefix storageos $cliopts volume inspect default/clivol
+  $short_run $prefix storageos $cliopts volume inspect default/clivol
   assert_line --partial "\"name\": \"clivol\""
   assert_line --partial "\"description\": \"test vol"\"
   assert_line --partial "\"env\": \"test"\"
@@ -107,6 +110,6 @@ load "../../test_helper"
 }
 
 @test "Remove updated volume using storageos cli" {
-  run $prefix storageos $cliopts volume rm default/clivol
+  $short_run $prefix storageos $cliopts volume rm default/clivol
   assert_success
 }

--- a/acceptance-tests/smoke/plugin-replication.bats
+++ b/acceptance-tests/smoke/plugin-replication.bats
@@ -2,53 +2,57 @@
 
 load ../../test_helper
 
+short_run="run ui_timeout"
+long_run="run long_timeout"
+
 @test "Create replicated volume" {
-  run $prefix2 docker volume create --driver storageos $createopts --opt storageos.feature.replicas=1 repl-vol
+  $short_run $prefix2 docker volume create --driver storageos $createopts --opt storageos.feature.replicas=1 repl-vol
   assert_success
 }
 
 @test "Confirm replicated volume is created (volume ls)" {
-  run $prefix2 docker volume ls
+  $short_run $prefix2 docker volume ls
+  echo $output
   assert_line --partial "repl-vol"
 }
 
 @test "Confirm replicated volume has 1 replica using storageos cli" {
-  run $prefix2 storageos $cliopts volume inspect default/repl-vol
+  $short_run $prefix2 storageos $cliopts volume inspect default/repl-vol
   assert_line --partial "\"storageos.feature.replicas\": \"1\"",
 }
 
 @test "Start a container and mount the replicated volume on node 2" {
-  run $prefix2 docker run -i -d --name mounter -v repl-vol:/data ubuntu /bin/bash
+  $long_run $prefix2 docker run -i -d --name mounter -v repl-vol:/data ubuntu /bin/bash
   assert_success
 }
 
 @test "Create a binary file" {
-  run $prefix2 docker exec -i 'mounter dd if=/dev/urandom of=/data/random bs=10M count=1'
+  $long_run $prefix2 docker exec -i 'mounter dd if=/dev/urandom of=/data/random bs=10M count=1'
   assert_output --partial "10 M"
 }
 
 @test "Get a checksum for that binary file" {
-  run $prefix2 'docker exec -i mounter /bin/bash -c "md5sum /data/random > /data/checksum"'
+  $short_run $prefix2 'docker exec -i mounter /bin/bash -c "md5sum /data/random > /data/checksum"'
   assert_success
 }
 
 @test "Confirm checksum on node 2" {
-  run $prefix2 docker exec -i mounter md5sum --check /data/checksum
+  $short_run $prefix2 docker exec -i mounter md5sum --check /data/checksum
   assert_success
 }
 
 @test "Stop container on node 2" {
-  run $prefix2 docker stop mounter
+  $long_run $prefix2 docker stop mounter
   assert_success
 }
 
 @test "Destroy container on node 2" {
-  run $prefix2 docker rm mounter
+  $long_run $prefix2 docker rm mounter
   assert_success
 }
 
 @test "Stop storageos on node 2" {
-  run $prefix2 docker plugin disable -f storageos
+  $long_run $prefix2 docker plugin disable -f storageos
   assert_success
 }
 
@@ -58,16 +62,16 @@ load ../../test_helper
 }
 
 @test "Confirm checksum on node 1" {
-  run $prefix docker run -i --rm -v repl-vol:/data ubuntu md5sum --check /data/checksum
+  $long_run $prefix docker run -i --rm -v repl-vol:/data ubuntu md5sum --check /data/checksum
   assert_success
 }
 
 @test "Re-start storageos on node 2" {
-  run $prefix2 docker plugin enable storageos
+  $long_run $prefix2 docker plugin enable storageos
   assert_success
 }
 
 @test "Delete volume using storageos cli" {
-  run $prefix storageos $cliopts volume rm -f default/repl-vol
+  $long_run $prefix storageos $cliopts volume rm -f default/repl-vol
   assert_success
 }

--- a/docker-plugin/docker-tests/secondnode.bats
+++ b/docker-plugin/docker-tests/secondnode.bats
@@ -2,61 +2,57 @@
 
 load "../../test_helper"
 
-short_run="run ui_timeout"
-long_run="run long_timeout"
-
 @test "Test: Install plugin for driver (storageos) on node 2" {
   #skip "This test works, faster for rev without it"
-  $short_run $prefix2 -t "docker plugin ls | grep storageos"
+  run $prefix2 -t "docker plugin ls | grep storageos"
   if [[ $status -eq 0 ]]; then
     skip
   fi
 
-  $long_run $prefix2 docker plugin disable storageos -f
-  $long_run $prefix2 docker plugin rm storageos
-  $long_run $prefix2 docker plugin install --grant-all-permissions --alias storageos $driver $pluginopts
+  run $prefix2 docker plugin disable storageos -f
+  run $prefix2 docker plugin rm storageos
+  run $prefix2 docker plugin install --grant-all-permissions --alias storageos $driver $pluginopts
+  sleep 60
   assert_success
-
-  wait_for_volumes
 }
 
 @test "Test: Confirm volume is visible on second node (volume ls) using driver (storageos)" {
-  $short_run $prefix2 docker volume ls
+  run $prefix2 docker volume ls
   assert_line --partial "testvol"
 }
 
 @test "Start a container and mount the volume on node 2" {
-  $long_run $prefix2 docker run -i -d --name mounter -v testvol:/data ubuntu /bin/bash
+  run $prefix2 docker run -i -d --name mounter -v testvol:/data ubuntu /bin/bash
   assert_success
 }
 
 @test "Confirm textfile contents on the volume from node 2" {
-  $short_run $prefix2 docker exec -i mounter cat /data/foo.txt
+  run $prefix2 docker exec -i mounter cat /data/foo.txt
   assert_line --partial "testdata"
 }
 
 @test "Confirm checksum for binary file on node 2" {
-  $short_run $prefix2 docker exec -i mounter md5sum --check /data/checksum
+  run $prefix2 docker exec -i mounter md5sum --check /data/checksum
   assert_success
 }
 
 @test "Stop container on node 2" {
-  $long_run $prefix2 docker stop mounter
+  run $prefix2 docker stop mounter
   assert_success
 }
 
 @test "Destroy container on node 2" {
-  $long_run $prefix2 docker rm mounter
+  run $prefix2 docker rm mounter
   assert_success
 }
 
 @test "Remove volume" {
-  $short_run $prefix2 docker volume rm testvol
+  run $prefix2 docker volume rm testvol
   assert_success
 }
 
 @test "Confirm volume is removed from docker ls" {
   sleep 10
-  $short_run $prefix2 docker volume ls
+  run $prefix2 docker volume ls
   refute_output --partial 'testvol'
 }

--- a/docker-plugin/docker-tests/secondnode.bats
+++ b/docker-plugin/docker-tests/secondnode.bats
@@ -2,58 +2,61 @@
 
 load "../../test_helper"
 
+short_run="run ui_timeout"
+long_run="run long_timeout"
+
 @test "Test: Install plugin for driver (storageos) on node 2" {
   #skip "This test works, faster for rev without it"
-  run $prefix2 -t "docker plugin ls | grep storageos"
+  $short_run $prefix2 -t "docker plugin ls | grep storageos"
   if [[ $status -eq 0 ]]; then
     skip
   fi
 
-  run $prefix2 docker plugin disable storageos -f
-  run $prefix2 docker plugin rm storageos
-  run $prefix2 docker plugin install --grant-all-permissions --alias storageos $driver $pluginopts
+  $long_run $prefix2 docker plugin disable storageos -f
+  $long_run $prefix2 docker plugin rm storageos
+  $long_run $prefix2 docker plugin install --grant-all-permissions --alias storageos $driver $pluginopts
   assert_success
 
   wait_for_volumes
 }
 
 @test "Test: Confirm volume is visible on second node (volume ls) using driver (storageos)" {
-  run $prefix2 docker volume ls
+  $short_run $prefix2 docker volume ls
   assert_line --partial "testvol"
 }
 
 @test "Start a container and mount the volume on node 2" {
-  run $prefix2 docker run -i -d --name mounter -v testvol:/data ubuntu /bin/bash
+  $long_run $prefix2 docker run -i -d --name mounter -v testvol:/data ubuntu /bin/bash
   assert_success
 }
 
 @test "Confirm textfile contents on the volume from node 2" {
-  run $prefix2 docker exec -i mounter cat /data/foo.txt
+  $short_run $prefix2 docker exec -i mounter cat /data/foo.txt
   assert_line --partial "testdata"
 }
 
 @test "Confirm checksum for binary file on node 2" {
-  run $prefix2 docker exec -i mounter md5sum --check /data/checksum
+  $short_run $prefix2 docker exec -i mounter md5sum --check /data/checksum
   assert_success
 }
 
 @test "Stop container on node 2" {
-  run $prefix2 docker stop mounter
+  $long_run $prefix2 docker stop mounter
   assert_success
 }
 
 @test "Destroy container on node 2" {
-  run $prefix2 docker rm mounter
+  $long_run $prefix2 docker rm mounter
   assert_success
 }
 
 @test "Remove volume" {
-  run $prefix2 docker volume rm testvol
+  $short_run $prefix2 docker volume rm testvol
   assert_success
 }
 
 @test "Confirm volume is removed from docker ls" {
   sleep 10
-  run $prefix2 docker volume ls
+  $short_run $prefix2 docker volume ls
   refute_output --partial 'testvol'
 }

--- a/docker-plugin/docker-tests/singlenode.bats
+++ b/docker-plugin/docker-tests/singlenode.bats
@@ -2,97 +2,100 @@
 
 load "../../test_helper"
 
+short_run="run ui_timeout"
+long_run="run long_timeout"
+
 @test "Test: Install plugin " {
   #skip "Faster for rev during development without it - leave driver installed"
-  run $prefix -t "docker plugin ls | grep storageos"
+  $short_run $prefix -t "docker plugin ls | grep storageos"
   if [[ $status -eq 0 ]]; then
     skip
   fi
 
-  run $prefix docker plugin disable storageos -f
-  run $prefix docker plugin rm storageos
-  run $prefix docker plugin install --grant-all-permissions --alias storageos $driver $pluginopts
+  $long_run $prefix docker plugin disable storageos -f
+  $long_run $prefix docker plugin rm storageos
+  $long_run $prefix docker plugin install --grant-all-permissions --alias storageos $driver $pluginopts
   assert_success
 
   wait_for_volumes
 }
 
 @test "Test: Create volume using driver (storageos)" {
-  run $prefix docker volume create --driver storageos $createopts testvol
+  $short_run $prefix docker volume create --driver storageos $createopts testvol
   assert_success
 }
 
 @test "Test: Confirm volume is created (volume ls)" {
-  run $prefix docker volume ls
+  $short_run $prefix docker volume ls
   assert_line --partial "testvol"
 }
 
 @test "Test: Confirm docker volume inspect works using driver (storageos)" {
-  run $prefix docker volume inspect testvol
+  $short_run $prefix docker volume inspect testvol
   assert_line --partial "\"Driver\": \"storageos:latest"
 }
 
 @test "Start a container and mount the volume" {
-  run $prefix docker run -i -d --name mounter -v testvol:/data ubuntu /bin/bash
+  $long_run $prefix docker run -i -d --name mounter -v testvol:/data ubuntu /bin/bash
   assert_success
 }
 
 @test "Write a textfile to the volume" {
-  run $prefix 'docker exec -i -d mounter /bin/bash -c "echo \"testdata\" > /data/foo.txt"'
+  $short_run $prefix 'docker exec -i -d mounter /bin/bash -c "echo \"testdata\" > /data/foo.txt"'
   assert_success
 }
 
 @test "Confirm textfile contents on the volume" {
-  run $prefix docker exec -i mounter cat /data/foo.txt
+  $short_run $prefix docker exec -i mounter cat /data/foo.txt
   assert_line --partial "testdata"
 }
 
 @test "Create a binary file" {
-  run $prefix docker exec -i 'mounter dd if=/dev/urandom of=/data/random bs=10M count=1'
+  $long_run $prefix docker exec -i 'mounter dd if=/dev/urandom of=/data/random bs=10M count=1'
   assert_output --partial "10 M"
 }
 
 @test "get a checksum for that binary file" {
-  run $prefix 'docker exec -i -d mounter /bin/bash -c "md5sum /data/random > /data/checksum"'
+  $long_run $prefix 'docker exec -i -d mounter /bin/bash -c "md5sum /data/random > /data/checksum"'
   assert_success
 }
 
 @test "Confirm checksum" {
-  run $prefix docker exec -i -d mounter md5sum --check /data/checksum
+  $long_run $prefix docker exec -i -d mounter md5sum --check /data/checksum
   assert_success
 }
 
 @test "Stop container" {
-  run $prefix docker stop mounter
+  $long_run $prefix docker stop mounter
   assert_success
 }
 
 @test "Destroy container" {
-  run $prefix docker rm mounter
+  $long_run $prefix docker rm mounter
   assert_success
 }
 
 @test "Let's see if our data is still here" {
-  run $prefix docker run -i -d --name mounter -v testvol:/data ubuntu /bin/bash
+  $long_run $prefix docker run -i -d --name mounter -v testvol:/data ubuntu /bin/bash
   assert_success
 }
 
 @test "Confirm textfile contents are still on the volume" {
-  run $prefix docker exec -i mounter cat /data/foo.txt
+  $short_run $prefix docker exec -i mounter cat /data/foo.txt
   assert_line --partial "testdata"
 }
 
 @test "Confirm checksum persistence" {
-  run $prefix docker exec -i mounter md5sum --check /data/checksum
+  $long_run $prefix docker exec -i mounter md5sum --check /data/checksum
   assert_success
 }
 
 @test "Stop container" {
-  run $prefix docker stop mounter
+  $long_run $prefix docker stop mounter
   assert_success
 }
 
 @test "Destroy container" {
-  run $prefix docker rm mounter
+  $long_run $prefix docker rm mounter
   assert_success
 }

--- a/docker-plugin/docker-tests/singlenode.bats
+++ b/docker-plugin/docker-tests/singlenode.bats
@@ -2,100 +2,96 @@
 
 load "../../test_helper"
 
-short_run="run ui_timeout"
-long_run="run long_timeout"
-
 @test "Test: Install plugin " {
   #skip "Faster for rev during development without it - leave driver installed"
-  $short_run $prefix -t "docker plugin ls | grep storageos"
+  run $prefix -t "docker plugin ls | grep storageos"
   if [[ $status -eq 0 ]]; then
     skip
   fi
 
-  $long_run $prefix docker plugin disable storageos -f
-  $long_run $prefix docker plugin rm storageos
-  $long_run $prefix docker plugin install --grant-all-permissions --alias storageos $driver $pluginopts
+  run $prefix docker plugin disable storageos -f
+  run $prefix docker plugin rm storageos
+  run $prefix docker plugin install --grant-all-permissions --alias storageos $driver $pluginopts
   assert_success
-
-  wait_for_volumes
+  sleep 60
 }
 
 @test "Test: Create volume using driver (storageos)" {
-  $short_run $prefix docker volume create --driver storageos $createopts testvol
+  run $prefix docker volume create --driver storageos $createopts testvol
   assert_success
 }
 
 @test "Test: Confirm volume is created (volume ls)" {
-  $short_run $prefix docker volume ls
+  run $prefix docker volume ls
   assert_line --partial "testvol"
 }
 
 @test "Test: Confirm docker volume inspect works using driver (storageos)" {
-  $short_run $prefix docker volume inspect testvol
+  run $prefix docker volume inspect testvol
   assert_line --partial "\"Driver\": \"storageos:latest"
 }
 
 @test "Start a container and mount the volume" {
-  $long_run $prefix docker run -i -d --name mounter -v testvol:/data ubuntu /bin/bash
+  run $prefix docker run -i -d --name mounter -v testvol:/data ubuntu /bin/bash
   assert_success
 }
 
 @test "Write a textfile to the volume" {
-  $short_run $prefix 'docker exec -i -d mounter /bin/bash -c "echo \"testdata\" > /data/foo.txt"'
+  run $prefix 'docker exec -i -d mounter /bin/bash -c "echo \"testdata\" > /data/foo.txt"'
   assert_success
 }
 
 @test "Confirm textfile contents on the volume" {
-  $short_run $prefix docker exec -i mounter cat /data/foo.txt
+  run $prefix docker exec -i mounter cat /data/foo.txt
   assert_line --partial "testdata"
 }
 
 @test "Create a binary file" {
-  $long_run $prefix docker exec -i 'mounter dd if=/dev/urandom of=/data/random bs=10M count=1'
+  run $prefix docker exec -i 'mounter dd if=/dev/urandom of=/data/random bs=10M count=1'
   assert_output --partial "10 M"
 }
 
 @test "get a checksum for that binary file" {
-  $long_run $prefix 'docker exec -i -d mounter /bin/bash -c "md5sum /data/random > /data/checksum"'
+  run $prefix 'docker exec -i -d mounter /bin/bash -c "md5sum /data/random > /data/checksum"'
   assert_success
 }
 
 @test "Confirm checksum" {
-  $long_run $prefix docker exec -i -d mounter md5sum --check /data/checksum
+  run $prefix docker exec -i -d mounter md5sum --check /data/checksum
   assert_success
 }
 
 @test "Stop container" {
-  $long_run $prefix docker stop mounter
+  run $prefix docker stop mounter
   assert_success
 }
 
 @test "Destroy container" {
-  $long_run $prefix docker rm mounter
+  run $prefix docker rm mounter
   assert_success
 }
 
 @test "Let's see if our data is still here" {
-  $long_run $prefix docker run -i -d --name mounter -v testvol:/data ubuntu /bin/bash
+  run $prefix docker run -i -d --name mounter -v testvol:/data ubuntu /bin/bash
   assert_success
 }
 
 @test "Confirm textfile contents are still on the volume" {
-  $short_run $prefix docker exec -i mounter cat /data/foo.txt
+  run $prefix docker exec -i mounter cat /data/foo.txt
   assert_line --partial "testdata"
 }
 
 @test "Confirm checksum persistence" {
-  $long_run $prefix docker exec -i mounter md5sum --check /data/checksum
+  run $prefix docker exec -i mounter md5sum --check /data/checksum
   assert_success
 }
 
 @test "Stop container" {
-  $long_run $prefix docker stop mounter
+  run $prefix docker stop mounter
   assert_success
 }
 
 @test "Destroy container" {
-  $long_run $prefix docker rm mounter
+  run $prefix docker rm mounter
   assert_success
 }

--- a/node-join/install.bats
+++ b/node-join/install.bats
@@ -3,6 +3,9 @@
 # is this test up to date?
 load ../test_helper
 
+short_run="run ui_timeout"
+long_run="run long_timeout"
+
 @test "IP list join [INSTALL]" {
   AIP1=$(echo $prefix | cut -f 2 -d'@')
   AIP2=$(echo $prefix2 | cut -f 2 -d'@')
@@ -27,7 +30,7 @@ load ../test_helper
 
   for i in "${arr[@]}"
   do
-    run $i docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$join
+    $long_run $i docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$join
     assert_success
   done
 
@@ -41,7 +44,7 @@ load ../test_helper
   do
     printf "Checking state on %s\n" "$i"
 
-    run $i storageos $cliopts node ls --format {{.Name}}
+    $short_run $i storageos $cliopts node ls --format {{.Name}}
     assert_success
 
     hosts=$(echo $output | wc -w)
@@ -58,7 +61,7 @@ load ../test_helper
   do
     #run $i docker container kill storageos
     #run $i docker container rm storageos
-    run $i docker plugin rm -f storageos
+    $long_run $i docker plugin rm -f storageos
     run $i rm -rf /var/lib/storageos/kv
     assert_success
   done
@@ -76,7 +79,7 @@ load ../test_helper
 
   for i in "${arr[@]}"
   do
-    run $i docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$join
+    $long_run $i docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$join
     assert_success
   done
 
@@ -88,7 +91,7 @@ load ../test_helper
 
   for i in "${arr[@]}"
   do
-    run $i storageos $cliopts node ls --format {{.Name}}
+    $short_run $i storageos $cliopts node ls --format {{.Name}}
     assert_success
 
     hosts=$(echo $output | wc -w)
@@ -103,7 +106,7 @@ load ../test_helper
 
   for i in "${arr[@]}"
   do
-    run $i docker plugin rm -f storageos
+    $long_run $i docker plugin rm -f storageos
     run $i rm -rf /var/lib/storageos/kv
     assert_success
   done
@@ -121,7 +124,7 @@ load ../test_helper
 
   for i in "${arr[@]}"
   do
-    run $i docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$join
+    $long_run $i docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$join
     assert_success
   done
 
@@ -133,7 +136,7 @@ load ../test_helper
 
   for i in "${arr[@]}"
   do
-    run $i storageos $cliopts node ls --format {{.Name}}
+    $short_run $i storageos $cliopts node ls --format {{.Name}}
     assert_success
 
     hosts=$(echo $output | wc -w)
@@ -148,7 +151,7 @@ load ../test_helper
 
   for i in "${arr[@]}"
   do
-    run $i docker plugin rm -f storageos
+    $long_run $i docker plugin rm -f storageos
     run $i rm -rf /var/lib/storageos/kv
     assert_success
   done
@@ -166,7 +169,7 @@ load ../test_helper
 
   for i in "${arr[@]}"
   do
-    run $i docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$join
+    $long_run $i docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$join
     assert_success
   done
 
@@ -178,7 +181,7 @@ load ../test_helper
 
   for i in "${arr[@]}"
   do
-    run $i storageos $cliopts node ls --format {{.Name}}
+    $short_run $i storageos $cliopts node ls --format {{.Name}}
     assert_success
 
     hosts=$(echo $output | wc -w)
@@ -193,7 +196,7 @@ load ../test_helper
 
   for i in "${arr[@]}"
   do
-    run $i docker plugin rm -f storageos
+    $long_run $i docker plugin rm -f storageos
     run $i rm -rf /var/lib/storageos/kv
     assert_success
   done
@@ -211,7 +214,7 @@ load ../test_helper
 
   for i in "${arr[@]}"
   do
-    run $i docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$join
+    $long_run $i docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$join
     assert_success
   done
 
@@ -223,7 +226,7 @@ load ../test_helper
 
   for i in "${arr[@]}"
   do
-    run $i storageos $cliopts node ls --format {{.Name}}
+    $short_run $i storageos $cliopts node ls --format {{.Name}}
     assert_success
 
     hosts=$(echo $output | wc -w)
@@ -238,7 +241,7 @@ load ../test_helper
 
   for i in "${arr[@]}"
   do
-    run $i docker plugin rm -f storageos
+    $long_run $i docker plugin rm -f storageos
     run $i rm -rf /var/lib/storageos/kv
     assert_success
   done
@@ -256,7 +259,7 @@ load ../test_helper
 
   for i in "${arr[@]}"
   do
-    run $i docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$join
+    $long_run $i docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$join
     assert_success
   done
 
@@ -268,7 +271,7 @@ load ../test_helper
 
   for i in "${arr[@]}"
   do
-    run $i storageos $cliopts node ls --format {{.Name}}
+    $short_run $i storageos $cliopts node ls --format {{.Name}}
     assert_success
 
     hosts=$(echo $output | wc -w)
@@ -283,7 +286,7 @@ load ../test_helper
 
   for i in "${arr[@]}"
   do
-    run $i docker plugin rm -f storageos
+    $long_run $i docker plugin rm -f storageos
     run $i rm -rf /var/lib/storageos/kv
     assert_success
   done

--- a/node-join/join.bats
+++ b/node-join/join.bats
@@ -3,13 +3,15 @@
 # is this test up to date?
 load ../test_helper
 
+short_run="run ui_timeout"
+long_run="run long_timeout"
 
 @test "join after volume create [INSTALL]" {
   AIP1=$(echo $prefix | cut -f 2 -d'@')
   join=$(printf "%s:5705" "$AIP1")
 
   # One node for now
-  run $prefix docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$join
+  $long_run $prefix docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$join
   assert_success
 
   wait_for_volumes 1
@@ -17,7 +19,7 @@ load ../test_helper
 
 @test "join after volume create [VERIFY]" {
   echo "Creating volume"
-  run $prefix storageos $cliopts volume create -n default foo
+  $short_run $prefix storageos $cliopts volume create -n default foo
   assert_success
 
   echo "Installing on nodes 2 & 3"
@@ -25,10 +27,10 @@ load ../test_helper
   AIP2=$(echo $prefix2 | cut -f 2 -d'@')
   AIP3=$(echo $prefix3 | cut -f 2 -d'@')
 
-  run $prefix2 docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$(printf "%s:5705,%s:5705" "$AIP1" "AIP2")
+  $long_run $prefix2 docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$(printf "%s:5705,%s:5705" "$AIP1" "AIP2")
   assert_success
 
-  run $prefix3 docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$(printf "%s:5705,%s:5705,%s:5705" "$AIP1" "AIP2" "AIP3")
+  $long_run $prefix3 docker plugin install --alias storageos --grant-all-permissions $driver JOIN=$(printf "%s:5705,%s:5705,%s:5705" "$AIP1" "AIP2" "AIP3")
   assert_success
 
   wait_for_cluster
@@ -38,7 +40,7 @@ load ../test_helper
   echo "Confirming volume exists on all nodes"
   for i in "${arr[@]}"
   do
-    run $i storageos $cliopts volume ls --format {{.Name}}
+    $short_run $i storageos $cliopts volume ls --format {{.Name}}
     assert_success
 
     volumes=$(echo $output | wc -w)
@@ -53,7 +55,7 @@ load ../test_helper
 
   for i in "${arr[@]}"
   do
-    run $i docker plugin rm -f storageos
+    $long_run $i docker plugin rm -f storageos
     run $i rm -rf /var/lib/storageos/kv
     assert_success
   done

--- a/test_helper.bash
+++ b/test_helper.bash
@@ -14,3 +14,49 @@ prefix3="$PREFIX3"
 createopts="$CREATEOPTS"
 pluginopts="$PLUGINOPTS"
 cliopts="$CLIOPTS"
+
+
+# wait a reasonable time for a command to complete before stopping it and returning
+# returns 124 or 128+9 on timeout (the latter if the command required sigkill)
+function ui_timeout {
+  timeout_duration=10
+  kill_after=1 # additional time to wait after sending signal before killing
+
+  timeout -k $kill_after $timeout_duration $@
+  exit_status=$?
+
+  # timed out
+  if [[ $exit_status -eq 124 ]]; then
+      echo "Command timed out"
+  fi
+
+  # timed out, and needed to be killed (status 128+9)
+  if [[ $exit_status -eq 137 ]]; then
+      echo "Command timed out, and needed to be killed"
+  fi
+
+  return $exit_status
+}
+
+# wait a longer time for a command to complete before stopping it and returning
+# returns 124 or 128+9 on timeout (the latter if the command required sigkill)
+function long_timeout {
+  timeout_duration=120
+  kill_after=20 # additional time to wait after sending signal before killing
+
+  timeout -k $kill_after $timeout_duration $@
+  exit_status=$?
+
+  # timed out
+  if [[ $exit_status -eq 124 ]]; then
+      echo "Command timed out"
+  fi
+
+  # timed out, and needed to be killed (status 128+9)
+  if [[ $exit_status -eq 137 ]]; then
+      echo "Command timed out, and needed to be killed"
+  fi
+
+  return $exit_status
+
+}


### PR DESCRIPTION
Adds timeout utility functions
Uses these in the tests

Additional:
Adds logic to the provision script to attempt to provision each node up-to five times before failing
DO was particularly bad today, and this feature made testing easier for me.