### PR TITLE
allow custom image and use join env var

### DIFF
--- a/terraform/do/cluster/files/storageos.service.tpl
+++ b/terraform/do/cluster/files/storageos.service.tpl
@@ -12,7 +12,7 @@ EnvironmentFile=/etc/default/storageos
 ExecStartPre=-/usr/bin/docker kill storageos
 ExecStartPre=-/usr/bin/docker rm storageos
 ExecStartPre=/usr/bin/docker pull ${docker_image}
-ExecStart=/usr/bin/docker run --log-driver=fluentd --name storageos -e HOSTNAME -e ADVERTISE_IP -e INITIAL_CLUSTER --net=host --pid=host --privileged --cap-add SYS_ADMIN --device /dev/fuse -v /var/lib/storageos:/var/lib/storageos:rshared -v /run/docker/plugins:/run/docker/plugins ${docker_image} server
+ExecStart=/usr/bin/docker run --log-driver=fluentd --name storageos -e HOSTNAME -e ADVERTISE_IP -e JOIN --net=host --pid=host --privileged --cap-add SYS_ADMIN --device /dev/fuse -v /var/lib/storageos:/var/lib/storageos:rshared -v /run/docker/plugins:/run/docker/plugins ${docker_image} server
 ExecStop=/usr/bin/docker stop storageos
 
 [Install]

--- a/terraform/do/cluster/variables.tf
+++ b/terraform/do/cluster/variables.tf
@@ -19,8 +19,12 @@ variable "cli_version" {
   description = "Version of cli to download on each node"
 }
 
-variable "node_container_version" {
-  description = "Version of the storageos/node container to run"
+variable "storageos_image" {
+  description = "storageos image"
+}
+
+variable "storageos_version" {
+  description = "storageos version"
 }
 
 variable "region" {

--- a/terraform/do/runner.tf
+++ b/terraform/do/runner.tf
@@ -9,12 +9,13 @@ module "storageos_cluster"  {
   pvt_key_path="${var.pvt_key_path}"
   ubuntu_version="${var.os}"
   nbd="${var.nbd}"
+  storageos_image="${var.storageos_image}"
+  storageos_version="${var.storageos_version}"
   cli_version="${var.storageos_cli_version}"
   es_host="${var.es_host}"
   es_port="${var.es_port}"
   es_user="${var.es_user}"
   es_pass="${var.es_pass}"
-  node_container_version="${var.storageos_version}"
   ssh_fingerprint="${var.ssh_fingerprint}"
 }
 
@@ -74,6 +75,7 @@ MEMORY="${var.memory}"
 OS="${var.os}"
 NBD="${var.nbd}"
 PRODUCT="storageos"
+IMAGE="${var.storageos_image}"
 VERSION="${var.storageos_version}"
 EOF
     destination = "/etc/default/runner"

--- a/terraform/do/variables.tf
+++ b/terraform/do/variables.tf
@@ -30,7 +30,7 @@ variable "storageos_image" {
 
 variable "storageos_version" {
   description = "storageos version"
-  default = "0.8.1"
+  default = "0.9.0"
 }
 
 variable "storageos_cli_version" {

--- a/terraform/do/variables.tf
+++ b/terraform/do/variables.tf
@@ -23,6 +23,11 @@ variable "profile" {
   default = "default"
 }
 
+variable "storageos_image" {
+  description = "storageos image (defaults to storageos/node)"
+  default = "storageos/node"
+}
+
 variable "storageos_version" {
   description = "storageos version"
   default = "0.8.1"


### PR DESCRIPTION
Don't merge until 0.9, but otherwise ready.  Benchmark and stress test jobs have had the new vars added but are still pointing to vol-test:master.