### PR TITLE
Add ability to test against the node container

### DIFF
--- a/docker-container/01_install.bats
+++ b/docker-container/01_install.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+load ../test_helper
+
+short_run="run ui_timeout"
+long_run="run long_timeout"
+
+@test "Install containers on three nodes" {
+  join=$(printf "%s:5705,%s:5705,%s:5705" "${prefix#*@}" "${prefix2#*@}" "${prefix3#*@}")
+
+  run install_nodes "JOIN=$join"
+  assert_success
+
+  wait_for_cluster
+}
+
+@test "Verify cluster" {
+  declare -a arr=("$prefix" "$prefix2" "$prefix3")
+  for i in "${arr[@]}"; do
+    printf "Checking state on %s\n" "$i"
+
+    $short_run $i storageos $cliopts node ls --format {{.Name}}
+    assert_success
+
+    hosts=$(echo $output | wc -w)
+    printf "There should be three hosts in output:\n%s\n" "$output"
+
+    [ "$hosts" -eq 3 ]
+  done
+}
+
+@test "Remove containers" {
+  run remove_nodes
+  assert_success
+}

--- a/run_volume_tests.sh
+++ b/run_volume_tests.sh
@@ -56,6 +56,13 @@ Host tag      DO_TAG    $DO_TAG
 ==
 EOF
 
+pushd docker-container
+echo "-----------------------------"
+echo "running docker container (node) tests"
+echo "-----------------------------"
+  bats $BATS_OPTS .
+popd
+
 pushd startup-tests
 echo "-----------------------------"
 echo "running startup procedure tests"

--- a/test_helper.bash
+++ b/test_helper.bash
@@ -15,13 +15,62 @@ createopts="$CREATEOPTS"
 pluginopts="$PLUGINOPTS"
 cliopts="$CLIOPTS"
 
+# This string replace is UGLY, but it works for now
+node_driver=${driver/plugin/node}
+
+# OSX appears to not have timeout(1) by default, and the copy in coreutils is called gtimeout.
+# Almost everything however will have some kind of perl 5 variant.
+# This ugly one liner seemed less ugly than which + alias magic, and doesn't require coreutils.
+function timeout() { perl -e 'alarm shift; exec @ARGV' "$@"; }
+
+# takes env pairs as args, eg. "install_nodes 'JOIN=192.168.0.2' 'OTHERVAR=othervalue'"
+function install_nodes {
+  extra_env=""
+
+  # build set of aditional env vars
+  for i in "$@"; do
+      extra_env+=$(printf -- '-e %s ' "$i")
+  done
+  printf "Adding additional env vars:\n\t%s\n" "$extra_env"
+
+  declare -a arr=("$prefix" "$prefix2" "$prefix3")
+  for i in "${arr[@]}"; do
+    long_timeout "$i" docker run -d --name storageos \
+      "$extra_env" \
+      -e HOSTNAME \
+      -e ADVERTISE_IP="${i#*@}" \
+      --net=host \
+      --pid=host \
+      --privileged \
+      --cap-add SYS_ADMIN \
+      --device /dev/fuse \
+      -v /var/lib/storageos:/var/lib/storageos:rshared \
+      -v /run/docker/plugins:/run/docker/plugins \
+      "$node_driver" server
+    # ensure that the node was installed
+    [ $? -eq 0 ]
+  done
+}
+
+function remove_nodes {
+  declare -a arr=("$prefix" "$prefix2" "$prefix3")
+  for i in "${arr[@]}"; do
+    long_timeout "$i" docker rm -f storageos
+    [ $? -eq 0 ]
+  done
+}
+
 # wait a reasonable time for a command to complete before stopping it and returning
 # returns 124 or 128+9 on timeout (the latter if the command required sigkill)
 function ui_timeout {
   timeout_duration=10
-  kill_after=1 # additional time to wait after sending signal before killing
+  # kill_after=1 # additional time to wait after sending signal before killing
 
-  timeout -k $kill_after $timeout_duration $@
+  # Our timeout alternative doesn't support kill after behaviour, an asumption is made that the
+  # child processes will not be atempting to catch SIGALARM. If this turns out to not be the case
+  # then we will need to reconsider.
+  #timeout -k $kill_after $timeout_duration $@
+  timeout $timeout_duration $@
   exit_status=$?
 
   # timed out
@@ -41,9 +90,13 @@ function ui_timeout {
 # returns 124 or 128+9 on timeout (the latter if the command required sigkill)
 function long_timeout {
   timeout_duration=120
-  kill_after=20 # additional time to wait after sending signal before killing
+  # kill_after=20 # additional time to wait after sending signal before killing
 
-  timeout -k $kill_after $timeout_duration $@
+  # Our timeout alternative doesn't support kill after behaviour, an asumption is made that the
+  # child processes will not be atempting to catch SIGALARM. If this turns out to not be the case
+  # then we will need to reconsider.
+  # timeout -k $kill_after $timeout_duration $@
+  timeout $timeout_duration $@
   exit_status=$?
 
   # timed out
@@ -66,7 +119,7 @@ function wait_for_cluster {
 
   printf "VARS %s %s\n" "$no_of_nodes" "$max_time"
 
-  for ((number=0;number < $max_time;number++))
+  for ((number=0;number<max_time;number++))
   {
     sleep "1s"
     health=$($prefix storageos -u storageos -p storageos cluster health --format '{{.KV}}{{.NATS}}{{.Scheduler}}') || true
@@ -77,7 +130,7 @@ function wait_for_cluster {
       if [[ $(echo "$health" | wc -l) -eq $no_of_nodes ]]; then
         ok=1
 
-        # Every line should start with 'Healthy'
+        # Every line should read 'alive' for all services
         while read -r line; do
           if [[ "$line" != "alivealivealive" ]]; then
             ok=0
@@ -99,7 +152,7 @@ function wait_for_cluster {
 
 # Wait for the cluster to be available and volumes are provisionable
 function wait_for_volumes {
-    wait_for_cluster $1
+    wait_for_cluster "$1"
     sleep "15s" # CP has a safety sleep on newly provisioned nodes
     return 0
 }


### PR DESCRIPTION
Adds functions to install node clusters
Adds basic example test for node container
Fixes lack of timeout(1) command on OSX

Probably not yet merge-able as Jenkins doesn't push the node container